### PR TITLE
use full path to map dirname

### DIFF
--- a/dmysql-import-database
+++ b/dmysql-import-database
@@ -19,7 +19,7 @@ def runContainer(containerName, path, database = ""):
 	fileName = pathList[-1]
 
 	# Read the path and get the directory
-	dirname = os.path.dirname(path)
+	dirname = os.path.dirname(os.path.realpath(path))
 
 	if database:
 		print 'Importing {file} into database {database} using container {container}'.format(file=fileName, database=database, container=containerName)


### PR DESCRIPTION
fixes scenario where file is called from current working directory. 

dirname returns "" when using local path.  
You can get around this by mounting the volume to the realpath of the file's directory.
